### PR TITLE
[Example][LB] Unify the variable rules in unit tests

### DIFF
--- a/loadbalancer/tests/test_backend_server.py
+++ b/loadbalancer/tests/test_backend_server.py
@@ -17,7 +17,7 @@ class TestingNginx(unittest.TestCase):
     @pulumi.runtime.test
     def test_server_tags(self):
         def check_tags(args):
-            result_urn, result_tags = args
+            actual_urn, actual_tags = args
             expected_tags = ["webserver"]
-            self.assertCountEqual(result_tags, expected_tags, f'server {result_urn} must have webserver tag')
+            self.assertCountEqual(actual_tags, expected_tags, f'server {actual_urn} must have webserver tag')
         return pulumi.Output.all(test_server._name, test_server.tags).apply(check_tags)

--- a/loadbalancer/tests/test_firewall.py
+++ b/loadbalancer/tests/test_firewall.py
@@ -11,18 +11,19 @@ class TestingFirewall(unittest.TestCase):
     @pulumi.runtime.test
     def test_firewall_ports(self):
         def check_ports(args):
-            result_ports = []
+            actual_ports = []
+            expected_ports = ["tcp_80"]
             for allow in args[0]:
                 for port in allow["ports"]:
-                    result_ports.append(allow["protocol"] + "_" + port)
-            self.assertCountEqual(result_ports, ['tcp_80'])
+                    actual_ports.append(allow["protocol"] + "_" + port)
+            self.assertCountEqual(actual_ports, expected_ports)
         return pulumi.Output.all(test_network_base["compute_firewall"].allows).apply(check_ports)
 
     # check 2: Firewall should only accept the request from health probe and LB
     @pulumi.runtime.test
     def test_source_ranges(self):
         def check_source_ranges(args):
-            result_source_ranges = args[0]
-            expected_source_ranges = ['1.2.3.4', '35.191.0.0/16', '130.211.0.0/22']
-            self.assertCountEqual(expected_source_ranges, result_source_ranges)
+            actual_source_ranges = args[0]
+            expected_source_ranges = ["1.2.3.4", "35.191.0.0/16", "130.211.0.0/22"]
+            self.assertCountEqual(actual_source_ranges, expected_source_ranges)
         return pulumi.Output.all(test_network_base["compute_firewall"].source_ranges).apply(check_source_ranges)

--- a/loadbalancer/tests/test_lb.py
+++ b/loadbalancer/tests/test_lb.py
@@ -12,18 +12,18 @@ class TestingLoadBalancer(unittest.TestCase):
     def test_urlmap_host_rules(self):
         def check_host_rules(args):
             host_rules = args[0]
-            result_rules = []
+            actual_rules = []
             expected_rules = [{
                 "host": "*",
                 "path_matcher": "allpaths"
             }]
             for rule in host_rules:
                 for host in rule["hosts"]:
-                    result_rules.append({
+                    actual_rules.append({
                         "host": host,
                         "path_matcher": rule["pathMatcher"]
                     })
-            self.assertCountEqual(result_rules, expected_rules)
+            self.assertCountEqual(actual_rules, expected_rules)
         return pulumi.Output.all(test_load_balancer["url_map"].host_rules).apply(check_host_rules)
 
     # check 2: check patch matchers
@@ -31,7 +31,7 @@ class TestingLoadBalancer(unittest.TestCase):
     def test_urlmap_path_matchers(self):
         def check_path_matchers(args):
             path_matchers = args[0]
-            result_matchers = []
+            actual_matchers = []
             expected_matchers = [{
                 "name": "allpaths",
                 "path": "/*",
@@ -40,10 +40,10 @@ class TestingLoadBalancer(unittest.TestCase):
             for matcher in path_matchers:
                 for rules in matcher["pathRules"]:
                     for path in rules["paths"]:
-                        result_matchers.append({
+                        actual_matchers.append({
                             "name": matcher["name"],
                             "path": path,
                             "service": rules["service"]
                         })
-            self.assertCountEqual(result_matchers, expected_matchers)
-        pulumi.Output.all(test_load_balancer["url_map"].path_matchers).apply(check_path_matchers)
+            self.assertCountEqual(actual_matchers, expected_matchers)
+        return pulumi.Output.all(test_load_balancer["url_map"].path_matchers).apply(check_path_matchers)


### PR DESCRIPTION
closes #5 

WHY:
1. Better identify actual result and expected result
2. Unify the order of parameter in assert

HOW:
1. Use "actual" as prefix for actual result
2. Order the parameters by (actual, expected)